### PR TITLE
[Fix] 작년의 오늘 기능 에러 해결

### DIFF
--- a/back/src/diary/diary.service.ts
+++ b/back/src/diary/diary.service.ts
@@ -181,9 +181,9 @@ export class DiaryService {
         where: {
           user: { id: user.id },
           diaryDate: Raw(
-            (alias) => `TO_CHAR(${alias}, 'MM-DD') = :mmdd`,
-            { mmdd: `${month}-${day}` }
-          ),
+            () => `TO_CHAR("diaryDate", 'MM-DD') = :mmdd AND "diaryDate" != :today`,
+            { mmdd: `${month}-${day}`, today: date, }
+          ),   
         },
       });
 


### PR DESCRIPTION
- 계획 대로라면 오늘과 날짜만 같고 년도가 다른 일기 데이터를 가져와야 함 
- 하지만 내부의 코드 상 그러지 못한 버그 발견
- 해결!